### PR TITLE
Updates 'librarian-puppet'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.1.0'
 gem 'facter', ENV['FACTER_VERSION'] || '~> 1.6.0'
 
 # Dependency management.
-gem 'librarian-puppet-maestrodev', '~> 0.9.0'
+gem 'librarian-puppet'
 
 # Testing utilities.
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,18 +5,22 @@ GEM
     facter (1.6.18)
     hiera (1.2.1)
       json_pure
-    highline (1.6.20)
+    highline (1.6.21)
     json (1.8.1)
     json_pure (1.8.0)
-    librarian (0.1.1)
+    librarian (0.1.2)
       highline
       thor (~> 0.15)
-    librarian-puppet-maestrodev (0.9.10.1)
+    librarian-puppet (0.9.13)
       json
-      librarian (>= 0.1.1)
+      librarian (>= 0.1.2)
+      open3_backport
     metaclass (0.0.1)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
+    open3_backport (0.0.3)
+      open4 (~> 1.3.0)
+    open4 (1.3.3)
     puppet (3.1.1)
       facter (~> 1.6)
       hiera (~> 1.0)
@@ -47,7 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   facter (~> 1.6.0)
-  librarian-puppet-maestrodev (~> 0.9.0)
+  librarian-puppet
   puppet (~> 3.1.0)
   puppet-lint (~> 0.3.0)
   puppet-syntax


### PR DESCRIPTION
The librarian-puppet gem has been renamed from `librarian-puppet-maestrodev`
to `librarian-puppet`. This commit makes that change. It does not lock the
version in the Gemfile, as the Gemfile.lock does this instead.
