### PR TITLE
Change path and exec method in Puppet

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,16 +15,13 @@ Vagrant.configure("2") do |config|
   config.vm.box     = "puppet-precise64"
   config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64.box"
 
-  config.vm.provision :puppet do |puppet|
-    puppet.manifest_file  = "site.pp"
-    puppet.manifests_path = "manifests"
-    puppet.module_path    = [ "modules", "vendor/modules" ]
-    puppet.options = [
-      "--verbose", "--summarize",
-      "--reports", "store",
-      "--hiera_config", "/vagrant/hiera.yaml",
-    ]
-  end
+  config.vm.synced_folder '.', '/opt/puppet'
+
+  config.vm.provision :shell,
+    :inline => 'exec /opt/puppet/tools/bootstrap'
+  config.vm.provision :shell,
+    :inline => 'exec /opt/puppet/tools/puppet-apply $@',
+    :args   => '--verbose --summarize --environment development'
 
   nodes.each do |node_name, node_opts|
     config.vm.define node_name do |node|

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -5,4 +5,4 @@
 :backends:
   - yaml
 :yaml:
-  :datadir: '/vagrant/hieradata'
+  :datadir: '/opt/puppet/hieradata'

--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if ! dpkg -l puppetlabs-release >/dev/null; then
+  TMPFILE=$(mktemp)
+  wget -qO ${TMPFILE} http://apt.puppetlabs.com/puppetlabs-release-precise.deb
+  dpkg -i ${TMPFILE}
+  rm ${TMPFILE}
+  apt-get update -qq
+fi
+
+apt-get install -y -qq --no-upgrade ruby1.9.1 puppet='3.2.*' puppet-common='3.2.*'

--- a/tools/puppet-apply
+++ b/tools/puppet-apply
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+PUPPET_PATH=/opt/puppet
+sudo puppet apply \
+  --hiera_config ${PUPPET_PATH}/hiera.yaml \
+  --modulepath ${PUPPET_PATH}/modules:${PUPPET_PATH}/vendor/modules \
+  ${PUPPET_PATH}/manifests/site.pp \
+  $@


### PR DESCRIPTION
This commit is prior art from https://github.com/alphagov/govuk_mirror-puppet/commit/31ec3c6e038326e9f152c01e3ea0dee4de2aae63.
From its commit message:

Replace Vagrant's builtin provisioner for Puppet with our own shared folder and
shell script. This will allow us to use a consistent filesystem path in Vagrant
and production which is useful for Hiera, in particular, because unlike
extlookup the `datadir` path can't be computed relative to another Puppet
variable.
