### PR TITLE
Make Gemfile work with newer versions of ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,16 @@ source 'https://rubygems.org'
 # Travis will remove Gemfile.lock before installing deps. As such, it is
 # advisable to pin major versions in this Gemfile.
 
-# Puppet core.
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.6.1'
+# Puppet core. (Puppet and facter)
+# Ruby 2.1.x and perhaps others are incompatible with older versions of puppet
+if RUBY_VERSION >= "2.1"
+  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.6.1'
+else
+  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.1.0'
+end
+
 gem 'facter', ENV['FACTER_VERSION'] || '~> 1.6.0'
+
 
 # Dependency management.
 gem 'librarian-puppet'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # advisable to pin major versions in this Gemfile.
 
 # Puppet core.
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.1.0'
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.6.1'
 gem 'facter', ENV['FACTER_VERSION'] || '~> 1.6.0'
 
 # Dependency management.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,11 @@ GEM
   specs:
     diff-lcs (1.2.4)
     facter (1.6.18)
-    hiera (1.2.1)
+    hiera (1.3.3)
       json_pure
     highline (1.6.21)
     json (1.8.1)
-    json_pure (1.8.0)
+    json_pure (1.8.1)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
@@ -21,9 +21,11 @@ GEM
     open3_backport (0.0.3)
       open4 (~> 1.3.0)
     open4 (1.3.3)
-    puppet (3.1.1)
-      facter (~> 1.6)
+    puppet (3.6.1)
+      facter (> 1.6, < 3)
       hiera (~> 1.0)
+      json_pure
+      rgen (~> 0.6.5)
     puppet-lint (0.3.2)
     puppet-syntax (0.0.4)
       puppet (>= 2.7.0)
@@ -34,6 +36,7 @@ GEM
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
     rake (10.0.4)
+    rgen (0.6.6)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -52,7 +55,7 @@ PLATFORMS
 DEPENDENCIES
   facter (~> 1.6.0)
   librarian-puppet
-  puppet (~> 3.1.0)
+  puppet (~> 3.6.1)
   puppet-lint (~> 0.3.0)
   puppet-syntax
   puppetlabs_spec_helper (~> 0.4.0)


### PR DESCRIPTION
Puppet 3.1.0 wouldn't play nicely with my system ruby:
https://github.com/puppetlabs/puppet/pull/2184/files

This was fixed in newer versions of the puppet gem, so I've just updated the Gemfile to a newer version, with some logic to leave users of ruby < 2.1.0 on the puppet version that was there before.

I'll leave it to you guys to decide if you'd rather just bump everyone up, but I figured there was a reason for specifying ~>3.1.0
