### PR TITLE
Deprecate `import` statement

### DIFF
--- a/manifests/nodes.pp
+++ b/manifests/nodes.pp
@@ -1,4 +1,0 @@
-# Use hiera as a lightweight ENC.
-node default {
-  hiera_include('classes')
-}

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -1,1 +1,4 @@
-import 'nodes'
+# Use hiera as a lightweight ENC.
+node default {
+  hiera_include('classes')
+}


### PR DESCRIPTION
Puppet announced that `import` is being fully deprecated by Puppet 4's
released date. Currently, we make use of this in this repository to import
the content of `nodes.pp` (which then looks up the values associated with
the `classes` key in Hiera).

The deprecation notice is available at
http://docs.puppetlabs.com/puppet/latest/reference/lang_import.html#deprecation-notice.
This commit allows us to follow the first of the two suggested workarounds.
