### PR TITLE
Update 'puppetlabs/stdlib' to 4.5.0

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,3 +1,3 @@
 forge 'https://forgeapi.puppetlabs.com'
 
-mod 'puppetlabs/stdlib', '~> 3.0'
+mod 'puppetlabs/stdlib', '~> 4.2'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,8 +1,8 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    puppetlabs/stdlib (3.2.0)
+    puppetlabs-stdlib (4.5.0)
 
 DEPENDENCIES
-  puppetlabs/stdlib (~> 3.0)
+  puppetlabs-stdlib (~> 4.2)
 


### PR DESCRIPTION
The latest version of Puppet's standard library is 4.5.0. The changelog can be
seen at https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/CHANGELOG.md
