### PR TITLE
bump puppetlabs-stdlib to 4.5.1 because of CVE-2015-1029

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,3 +1,3 @@
 forge 'https://forgeapi.puppetlabs.com'
 
-mod 'puppetlabs/stdlib', '~> 4.2'
+mod 'puppetlabs/stdlib', '~> 4.5'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,8 +1,8 @@
 FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
-    puppetlabs-stdlib (4.5.0)
+    puppetlabs-stdlib (4.5.1)
 
 DEPENDENCIES
-  puppetlabs-stdlib (~> 4.2)
+  puppetlabs-stdlib (~> 4.5)
 


### PR DESCRIPTION
Versions of puppetlabs-stdlib prior to 4.5.1 suffered from a
[vulnerability](http://puppetlabs.com/security/cve/cve-2015-1029) where a nonprivileged user could pre-populate the
stdlib fact cache, potentially resulting in changing the behaviour of
the puppet run.

I bumped the Puppetfile too to exclude as many vulnerable versions as
possible without preventing upgrade to 4.6.  4.5.0 is still
allowed but that's the limitation of the ~> operator, and with 4.5.1 in
Puppetfile.lock it's unlikely a project started from this skeleton will
ever use 4.5.0.
