### PR TITLE
Upgrade Vagrant box to Ubuntu 14.04-x64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,7 @@ node_defaults = {
 }
 
 Vagrant.configure("2") do |config|
-  config.vm.box     = "puppet-precise64"
-  config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64.box"
+  config.vm.box     = "puppetlabs/ubuntu-14.04-64-puppet"
 
   config.vm.synced_folder '.', '/opt/puppet'
 


### PR DESCRIPTION
Previously, we were using an Ubuntu 12.04 image from the Puppet Labs
repository. This updates the image we're using to use Ubuntu 14.04 using the
Atlas notation ('username/boxname').

In this example, 'puppetlabs/ubuntu-14.04-64-puppet' will download
https://atlas.hashicorp.com/puppetlabs/boxes/ubuntu-14.04-64-puppet for the
correct provider as understood by the Vagrant binary running locally.
