### PR TITLE
Revert "Upgrade Vagrant box to Ubuntu 14.04-x64"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,8 @@ node_defaults = {
 }
 
 Vagrant.configure("2") do |config|
-  config.vm.box     = "puppetlabs/ubuntu-14.04-64-puppet"
+  config.vm.box     = "puppet-precise64"
+  config.vm.box_url = "http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-1204-x64.box"
 
   config.vm.synced_folder '.', '/opt/puppet'
 


### PR DESCRIPTION
There is an issue with this box when it's brought up from fresh, in that `/etc/apt/sources.d/puppetlabs.list` is put on the machine both by the image and by a provisioning script. Provisions fail because no value is provided to the prompt from Apt asking which to use. We should work out how to get around that, but in the meantime, we should revert this change.
