### PR TITLE
Force containerised Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+# Force containerised builds in Travis CI
+sudo: false
 # Ignore lock file to facilitate matrix builds.
 before_install: rm Gemfile.lock
 rvm:


### PR DESCRIPTION
Containerised builds in Travis CI are quicker, containers have use of more
resources, run on a new EC2 stack with more network throughput, are easier
to scale and have caching in-built.

See
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
