### PR TITLE
Upgrade Puppet to 3.8.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # advisable to pin major versions in this Gemfile.
 
 # Puppet core.
-gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.6.1'
+gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8.2'
 gem 'facter', ENV['FACTER_VERSION'] || '~> 1.6.0'
 
 # Dependency management.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,12 +20,12 @@ GEM
       activesupport (>= 3.0.0, < 4.2)
       faraday (>= 0.8, < 1.0)
       multi_json (~> 1.7)
-    hiera (1.3.3)
+    hiera (1.3.4)
       json_pure
     highline (1.6.21)
     i18n (0.6.11)
     json (1.8.1)
-    json_pure (1.8.1)
+    json_pure (1.8.2)
     librarian (0.1.2)
       highline
       thor (~> 0.15)
@@ -38,11 +38,10 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.10.1)
     multipart-post (2.0.0)
-    puppet (3.6.1)
+    puppet (3.8.2)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
-      rgen (~> 0.6.5)
     puppet-lint (0.3.2)
     puppet-syntax (0.0.4)
       puppet (>= 2.7.0)
@@ -55,7 +54,6 @@ GEM
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
     rake (10.0.4)
-    rgen (0.6.6)
     rspec (2.13.0)
       rspec-core (~> 2.13.0)
       rspec-expectations (~> 2.13.0)
@@ -77,7 +75,7 @@ PLATFORMS
 DEPENDENCIES
   facter (~> 1.6.0)
   librarian-puppet
-  puppet (~> 3.6.1)
+  puppet (~> 3.8.2)
   puppet-lint (~> 0.3.0)
   puppet-syntax
   puppetlabs_spec_helper (~> 0.4.0)


### PR DESCRIPTION
Puppet 3.6.1 is rather old, so fast-forward to Puppet 3.8.2 which is the
latest stable release before the 4.x.x family.

I've tested this, and it seems to work fine. There are no breaking changes,
as these are being applied by Puppet Labs to the 4.x.x family.

The Gemfile.lock was updated with `bundle update puppet`, to ensure dependencies
are properly updated to the correct versions.
