### PR TITLE
Install Puppet 3.8.x on hosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ rvm:
   - 1.9.3
   - ruby-head
 env:
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.8.2"
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -9,4 +9,4 @@ if ! dpkg -l puppetlabs-release >/dev/null; then
   apt-get update -qq
 fi
 
-apt-get install -y -qq --no-upgrade ruby1.9.1 puppet='3.2.*' puppet-common='3.2.*'
+apt-get install -y -qq --no-upgrade ruby1.9.1 puppet='3.8.*' puppet-common='3.8.*'


### PR DESCRIPTION
In 21ba35f, the Gemfile was updated to specify Puppet 3.8.x as a minimum, but
other important bits were missed out. This meant that hosts were being provisioned
with 3.2, and Travis was testing changes against the old version.

I noticed this because Apt repositories being checked for 3.2 packages returned no
results:

```
==> node0: dpkg-query: no packages found matching puppetlabs-release
```

Fixes this by enforcing 3.8.\* on hosts. Also changes Travis tests to point at 3.8.x release
now that this is used instead of older 3.1 and 3.2 releases.
